### PR TITLE
Bump parking_lot to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["concurrency", "memory-management", "data-structures"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-parking_lot = "0.10"
+parking_lot = "0.11"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
parking_lot 0.11 in turn has updated dependencies, which are required for building for Redox