### PR TITLE
Convert empty descending range ``10..0`` to ``(0..10).rev()``.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
         drop(objects);
         assert!(pool.try_pull().is_some());
 
-        for i in 10..0 {
+        for i in (10..0).rev() {
             let mut object = pool.objects.lock().pop().unwrap();
             assert_eq!(object.pop(), Some(i));
         }


### PR DESCRIPTION
The test function `e2e()` uses `10..0` for a descending range, but Rust requires `(0..10).rev()` instead.
