### PR TITLE
Added from_vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,11 @@ impl<T> Pool<T> {
     }
 
     #[inline]
+    pub fn from_vec(v: Vec<T>) -> Pool<T> {
+        Pool { objects: Mutex::new(v) }
+    }
+
+    #[inline]
     pub fn len(&self) -> usize {
         self.objects.lock().len()
     }


### PR DESCRIPTION
Hello! This PR seeks to add `from_vec` for `Pool<T>`.

Reason for adding, I have a use case where I need to reuse some `String` but the `String`s are unique and I don't care which `String` is pulled. The method `from_vec` easily facilitates that as I can create a `Vec<String>` with the contents I want and easily turn it to a pool. Figured that others might find this useful.

Please take a look at my PR and happy holidays! Thank you!