### PR TITLE
add owned reusable

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,10 +26,19 @@ static SIZES: &[usize] = &[
 ];
 
 fn basics(c: &mut Criterion) {
-    c.bench_function("pulling_from_pool", |b| {
+    let mut group = c.benchmark_group("pulling_from_pool");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    group.bench_function("borrowed", |b| {
         let pool = Pool::new(1, || ());
         b.iter(|| pool.try_pull())
     });
+
+    group.bench_function("owned", |b| {
+        let pool = std::sync::Arc::new(Pool::new(1, || ()));
+        b.iter(|| pool.try_pull_owned())
+    });
+    drop(group);
 
     c.bench_function("detach_from_pool", |b| {
         let pool = Pool::new(1, || ());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,17 @@
 //! let pool: Arc<Pool<T>> = Arc::new(Pool::new(cap, || T::new()));
 //! ```
 //!
+//! With threads, you may also find it convenient to have owned reused objects
+//! ```
+//! # use std::sync::Arc;
+//! # use object_pool::Pool;
+//! # type T = Vec<u32>;
+//! # const cap: usize = 5;
+//! let pool: Arc<Pool<T>> = Arc::new(Pool::new(cap, || T::new()));
+//!
+//! let owned_reusable = pool.pull_owned(|| T::new());
+//! ```
+//!
 //! # Warning
 //!
 //! Objects in the pool are not automatically reset, they are returned but NOT reset
@@ -68,6 +79,7 @@ use parking_lot::Mutex;
 use std::iter::FromIterator;
 use std::mem::{forget, ManuallyDrop};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 pub type Stack<T> = Vec<T>;
 
@@ -115,6 +127,29 @@ impl<T> Pool<T> {
     pub fn pull<F: Fn() -> T>(&self, fallback: F) -> Reusable<T> {
         self.try_pull()
             .unwrap_or_else(|| Reusable::new(self, fallback()))
+    }
+
+    /// Like try_pull, but returns an owned reusable wrapper.
+    ///
+    /// `try_pull_owned()` is about 10% slower than `try_pull()`, but it may be
+    /// necessary in some cases where you cannot satisfy a `'lifetime` borrow
+    /// check on the pool.
+    #[inline]
+    pub fn try_pull_owned(self: &Arc<Self>) -> Option<ReusableOwned<T>> {
+        self.objects
+            .lock()
+            .pop()
+            .map(|data| ReusableOwned::new(self.clone(), data))
+    }
+
+    /// Like pull, but returns an owned reusable wrapper.
+    ///
+    /// `pull_owned()` is about 10% slower than `pull()`, but it may be necessary in
+    /// some cases where you cannot satisfy a `'lifetime` borrow check on the pool.
+    #[inline]
+    pub fn pull_owned<F: Fn() -> T>(self: &Arc<Self>, fallback: F) -> ReusableOwned<T> {
+        self.try_pull_owned()
+            .unwrap_or_else(|| ReusableOwned::new(self.clone(), fallback()))
     }
 
     #[inline]
@@ -177,6 +212,59 @@ impl<'a, T> Drop for Reusable<'a, T> {
     #[inline]
     fn drop(&mut self) {
         unsafe { self.pool.attach(self.take()) }
+    }
+}
+
+pub struct ReusableOwned<T> {
+    pool: ManuallyDrop<Arc<Pool<T>>>,
+    data: ManuallyDrop<T>,
+}
+
+impl<T> ReusableOwned<T> {
+    #[inline]
+    pub fn new(pool: Arc<Pool<T>>, t: T) -> Self {
+        Self {
+            pool: ManuallyDrop::new(pool),
+            data: ManuallyDrop::new(t),
+        }
+    }
+
+    #[inline]
+    pub fn detach(mut self) -> (Arc<Pool<T>>, T) {
+        let ret = unsafe { self.take() };
+        forget(self);
+        ret
+    }
+
+    unsafe fn take(&mut self) -> (Arc<Pool<T>>, T) {
+        (
+            ManuallyDrop::take(&mut self.pool),
+            ManuallyDrop::take(&mut self.data),
+        )
+    }
+}
+
+impl<T> Deref for ReusableOwned<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for ReusableOwned<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl<T> Drop for ReusableOwned<T> {
+    #[inline]
+    fn drop(&mut self) {
+        let (pool, data) = unsafe { self.take() };
+        pool.attach(data);
     }
 }
 


### PR DESCRIPTION
OwnedReusable is like Reusable, but it works on `Arc` instead of `&'a`.

It is about 10% slower at 18.2ns per pull_owned() versus 16.5ns per
pull() on my laptop. This is still a marked improvement over allocating
expensive objects, and it opens up use cases where `&'a` on `Pool` is
not feasible.
For example, there is no lifetime association between a `tonic`
Interceptor and the `Request`, which means one cannot satisfy a borrow
of a shared pool in an Interceptor.
By offering `pull_owned()`, use cases like this are opened up. I've
endeavored to help guide users to pull() and try_pull() when possible,
as they are a little quicker.

![image](https://github.com/CJP10/object-pool/assets/86278669/de51f7ec-bb91-491a-ba15-b0d527197617)
